### PR TITLE
Add reimporting info and clarity on old format

### DIFF
--- a/pak-files.md
+++ b/pak-files.md
@@ -16,8 +16,35 @@ PAK files can be extracted using a tool called QuickBMS and a script written by 
 
 ## Reinserting modified PAK files
 
-Currently, there is no known way to modify PAK file contents, repackage them, and reinsert them into the game.
+***WARNING:*** **A modified file *cannot* be larger than the original file.**
+
+QuickBMS can also reimport files into archives. Unfortunately, this means you must replace files and cannot create new ones. For instructions, here is an excerpt from [QuickBMS's instructions](https://aluigi.altervista.org/papers/quickbms.txt) (section 3).
+
+>- Make a backup copy of the original archive!
+>
+>- Extract the files or only those you want to modify as
+>  you do normally via the GUI (double-click on quickbms.exe) OR via
+>  command-line like the following example:
+>
+>    `quickbms script.bms archive.pak output_folder`
+>
+>- Modify the extracted files leaving their size unchanged or
+>  smaller than before.
+>  I suggest to delete the files that have not been modified so that
+>  the reimporting process will be faster and safer. In the folder
+>  leave only the files you modified.
+>  Remember that their size must be smaller/equal than the original!
+>
+>- Reimport the files in the archive via the GUI by clicking on the
+>  file called "reimport2.bat" OR via command-line:
+>
+>    `quickbms -w -r -r script.bms archive.pak output_folder`
+>
+>- Test the game with the modified archive
+
+**Make sure to always use "reimport2.bat", as "reimport.bat" doesn't work and "reimport3.bat" corrupts the file.**
 
 ## Notes
 
 * Tests have shown that the game can access user-inserted PAK files. When wm_whiteroom.pak, a PAK file only found in the Japanese version of the game, is moved into the packfiles folder of the American release, the wm_whiteroom level contained in the PAK file loads just fine.
+* Any PAK file not in the "packfiles" folder use a different, older format. They cannot currently be opened, but seem to use the same format seen in Quake (2).


### PR DESCRIPTION
The pak archives in the root of the game's files use a different format than the ones seen in the pakfiles folder. It seems to be older and might use the same archive that is seen in Quake. It also contains unused text through old language files.